### PR TITLE
fix: direction naming in vertical mode

### DIFF
--- a/src/config/flex-slider-card-config-form.ts
+++ b/src/config/flex-slider-card-config-form.ts
@@ -146,8 +146,14 @@ const baseSchema = memoizeOne((
               select: {
                 mode: "dropdown",
                 options: [
-                  { value: "ltr", label: "Left to Right" },
-                  { value: "rtl", label: "Right to Left" },
+                  {
+                    value: "ltr",
+                    label: isVertical ? "Top to Bottom" : "Left to Right",
+                  },
+                  {
+                    value: "rtl",
+                    label: isVertical ? "Bottom to Top" : "Right to Left",
+                  },
                 ],
               },
             },

--- a/src/css/compact-flex-slider-css.ts
+++ b/src/css/compact-flex-slider-css.ts
@@ -1,4 +1,8 @@
-import { COMPACT_TITLE_HEIGHT, COMPACT_CONTAINER_PADDING } from "../type/constants";
+import {
+  COMPACT_TITLE_HEIGHT,
+  COMPACT_CONTAINER_PADDING,
+  COMPACT_VERTICAL_CONTAINER_PADDING,
+} from "../type/constants";
 
 export const compactFlexSliderCardCss: string = `
 
@@ -23,6 +27,14 @@ export const compactFlexSliderCardCss: string = `
 
   .container.compact.no-values {
     padding-bottom: ${COMPACT_CONTAINER_PADDING}px;
+  }
+
+  .container.compact.vertical.no-title {
+    padding-top: ${COMPACT_VERTICAL_CONTAINER_PADDING}px;
+  }
+
+  .container.compact.vertical.no-values {
+    padding-bottom: ${COMPACT_VERTICAL_CONTAINER_PADDING}px;
   }
 
   .container.compact .title {

--- a/src/css/compact-flex-slider-slider-css.ts
+++ b/src/css/compact-flex-slider-slider-css.ts
@@ -77,14 +77,14 @@ export const compactFlexSliderSliderCardCss: string = `
     background: var(--primary-color);
     width: 2px;
     height: 6px;
-    transform: translateX(-1px);
+    transform: translateX(0px);
   }
 
   .slider.compact.noUi-horizontal .noUi-marker-normal {
     background: var(--divider-color);
     width: 1px;
     height: 4px;
-    transform: translateX(-1px);
+    transform: translateX(0px);
   }
 
   .slider.compact.noUi-horizontal.noUi-rtl .noUi-marker-large {
@@ -208,9 +208,13 @@ export const compactFlexSliderSliderCardCss: string = `
   }
 
   .slider.compact.noUi-vertical .noUi-value-vertical {
-    transform: translateY(-60%);
+    transform: translateY(-65%);
     left: -12px;
     line-height: 1;
+  }
+
+  .slider.compact.noUi-vertical.noUi-rtl .noUi-value-vertical {
+    transform: translateY(25%);
   }
 
   .slider.compact.noUi-vertical.mirrored .noUi-value-vertical {

--- a/src/css/std-flex-slider-css.ts
+++ b/src/css/std-flex-slider-css.ts
@@ -1,4 +1,8 @@
-import { STD_TITLE_HEIGHT, STD_CONTAINER_PADDING } from "../type/constants";
+import {
+  STD_TITLE_HEIGHT,
+  STD_CONTAINER_PADDING,
+  STD_VERTICAL_CONTAINER_PADDING,
+} from "../type/constants";
 
 export const stdFlexSliderCardCss: string = `
 
@@ -23,6 +27,14 @@ export const stdFlexSliderCardCss: string = `
 
   .container.std.no-values {
     padding-bottom: ${STD_CONTAINER_PADDING}px;
+  }
+
+  .container.std.vertical.no-title {
+    padding-top: ${STD_VERTICAL_CONTAINER_PADDING}px;
+  }
+
+  .container.std.vertical.no-values {
+    padding-bottom: ${STD_VERTICAL_CONTAINER_PADDING}px;
   }
 
   .container.std .title {

--- a/src/css/std-flex-slider-slider-css.ts
+++ b/src/css/std-flex-slider-slider-css.ts
@@ -14,7 +14,7 @@ export const stdFlexSliderSliderCardCss: string = `
   .slider.std.noUi-target {
     height: 16px;
     background: color-mix(in srgb, var(--disabled-color) 30%, transparent);
-    border-radius: 15px;
+    border-radius: 10px;
     border: none;
     box-shadow: none;
     /* outline: 1px solid blue; /* Debugging border */
@@ -32,7 +32,7 @@ export const stdFlexSliderSliderCardCss: string = `
   }
 
   .slider.std .noUi-connects {
-    border-radius: 15px;
+    border-radius: 10px;
   }
 
   .slider.std.noUi-horizontal .noUi-handle {
@@ -142,7 +142,7 @@ export const stdFlexSliderSliderCardCss: string = `
     width: 16px;
     height: 100%;
     background: color-mix(in srgb, var(--disabled-color) 30%, transparent);
-    border-radius: 15px;
+    border-radius: 10px;
     border: none;
     box-shadow: none;
     /* outline: 1px solid blue; /* Debugging border */

--- a/src/css/std-flex-slider-slider-css.ts
+++ b/src/css/std-flex-slider-slider-css.ts
@@ -219,9 +219,13 @@ export const stdFlexSliderSliderCardCss: string = `
   }
 
   .slider.std.noUi-vertical .noUi-value-vertical {
-    transform: translateY(-50%);
+    transform: translateY(-55%);
     left: -8px;
     line-height: 1;
+  }
+
+  .slider.std.noUi-vertical.noUi-rtl .noUi-value-vertical {
+    transform: translateY(35%);
   }
 
   .slider.std.noUi-vertical.mirrored .noUi-value-vertical {

--- a/src/flex-slider-card-slider.ts
+++ b/src/flex-slider-card-slider.ts
@@ -10,7 +10,14 @@ import { FlexSliderCardFormat } from "./config/flex-slider-card-config-type";
 import { FlexSliderCardValuesBarMode, FlexSliderCardValuesBarSetModeCallback, FlexSliderCardValuesBarSetValueCallback } from "./flex-slider-card-valuesbar";
 import { debuglog, minutesToTime } from "./utils/utils";
 import { FlexSliderCardEntityType } from "./utils/entity-management";
-import { CARD_HEIGHT_BASE, INTER_CARD, COMPACT_CONTAINER_PADDING, COMPACT_TITLE_HEIGHT, STD_CONTAINER_PADDING, STD_TITLE_HEIGHT } from "./type/constants";
+import {
+  CARD_HEIGHT_BASE,
+  INTER_CARD,
+  COMPACT_TITLE_HEIGHT,
+  COMPACT_VERTICAL_CONTAINER_PADDING,
+  STD_TITLE_HEIGHT,
+  STD_VERTICAL_CONTAINER_PADDING,
+} from "./type/constants";
 
 // Extension de HTMLElement pour typer noUiSlider
 export interface NoUiSliderElement extends HTMLElement {
@@ -153,8 +160,11 @@ export class FlexSliderCardSlider extends LitElement {
       } else {
         const cardHeight = CARD_HEIGHT_BASE + (this.config.sliderVerticalHeight - 1) * (CARD_HEIGHT_BASE + INTER_CARD);
         const titleHeight = this.config.hasTitle ? (this.config.isStd ? STD_TITLE_HEIGHT : COMPACT_TITLE_HEIGHT) : 0;
-        const paddingTop = this.config.hasTitle ? 0 : (this.config.isStd ? STD_CONTAINER_PADDING : COMPACT_CONTAINER_PADDING);
-        const paddingBottom = this.config.hasValuesBar ? 0 : (this.config.isStd ? STD_CONTAINER_PADDING : COMPACT_CONTAINER_PADDING);
+        const containerPadding = this.config.isStd
+          ? STD_VERTICAL_CONTAINER_PADDING
+          : COMPACT_VERTICAL_CONTAINER_PADDING;
+        const paddingTop = this.config.hasTitle ? 0 : containerPadding;
+        const paddingBottom = this.config.hasValuesBar ? 0 : containerPadding;
         height = `calc(${cardHeight - titleHeight - paddingTop - paddingBottom}px - var(--ha-card-border-total, 0px))`;
       }
       return html`

--- a/src/type/constants.ts
+++ b/src/type/constants.ts
@@ -3,6 +3,8 @@ export const COMPACT_TITLE_HEIGHT = 20;
 
 export const STD_CONTAINER_PADDING = 5;
 export const COMPACT_CONTAINER_PADDING = 3;
+export const STD_VERTICAL_CONTAINER_PADDING = 12;
+export const COMPACT_VERTICAL_CONTAINER_PADDING = 7;
 
 export const CARD_HEIGHT_BASE = 56;
 export const INTER_CARD = 8;

--- a/tests/14_vertical_sections_ticks.yml
+++ b/tests/14_vertical_sections_ticks.yml
@@ -67,9 +67,13 @@ sections:
       - type: custom:flex-slider-card
         entities:
           - entity: input_number.inputnumbertest1
+            text: ""
           - entity: input_number.inputnumbertest2
+            text: ""
           - entity: input_number.inputnumbertest3
+            text: ""
           - entity: input_number.inputnumbertest4
+            text: ""
         min: 18
         max: 30
         step: 0.5
@@ -80,6 +84,7 @@ sections:
           rows: 3
         verticalheight: 2
         valuesbaractive: false
+        direction: rtl
       - type: tile
         entity: input_number.inputnumbertest1
         vertical: false
@@ -92,6 +97,7 @@ sections:
       - type: custom:flex-slider-card
         entities:
           - entity: input_number.inputnumbertest1
+            text: ""
         min: 18
         max: 30
         step: 0.25
@@ -102,6 +108,7 @@ sections:
         grid_options:
           columns: 6
         valuesbaractive: false
+        direction: rtl
       - type: custom:flex-slider-card
         entity_min: input_datetime.inputheuretestmin
         entity_max: input_datetime.inputheuretestmax

--- a/tests/14_vertical_sections_ticks.yml
+++ b/tests/14_vertical_sections_ticks.yml
@@ -67,9 +67,13 @@ sections:
       - type: custom:flex-slider-card
         entities:
           - entity: input_number.inputnumbertest1
+            text: ""
           - entity: input_number.inputnumbertest2
+            text: ""
           - entity: input_number.inputnumbertest3
+            text: ""
           - entity: input_number.inputnumbertest4
+            text: ""
         min: 18
         max: 30
         step: 0.5
@@ -80,6 +84,7 @@ sections:
           rows: 3
         verticalheight: 2
         valuesbaractive: false
+        direction: rtl
       - type: tile
         entity: input_number.inputnumbertest1
         vertical: false

--- a/tests/15_vertical_sections_bubbles_ticks.yml
+++ b/tests/15_vertical_sections_bubbles_ticks.yml
@@ -69,9 +69,13 @@ sections:
       - type: custom:flex-slider-card
         entities:
           - entity: input_number.inputnumbertest1
+            text: ""
           - entity: input_number.inputnumbertest2
+            text: ""
           - entity: input_number.inputnumbertest3
+            text: ""
           - entity: input_number.inputnumbertest4
+            text: ""
         bubblesactive: true
         ticksactive: true
         min: 18
@@ -86,6 +90,7 @@ sections:
           rows: 3
         verticalheight: 2
         valuesbaractive: false
+        direction: rtl
       - type: tile
         entity: input_number.inputnumbertest1
         vertical: false
@@ -98,6 +103,7 @@ sections:
       - type: custom:flex-slider-card
         entities:
           - entity: input_number.inputnumbertest1
+            text: ""
         bubblesactive: true
         ticksactive: true
         min: 18
@@ -112,6 +118,7 @@ sections:
         grid_options:
           columns: 6
         valuesbaractive: false
+        direction: rtl
       - type: custom:flex-slider-card
         entity_min: input_datetime.inputheuretestmin
         entity_max: input_datetime.inputheuretestmax

--- a/tests/15_vertical_sections_bubbles_ticks.yml
+++ b/tests/15_vertical_sections_bubbles_ticks.yml
@@ -69,9 +69,13 @@ sections:
       - type: custom:flex-slider-card
         entities:
           - entity: input_number.inputnumbertest1
+            text: ""
           - entity: input_number.inputnumbertest2
+            text: ""
           - entity: input_number.inputnumbertest3
+            text: ""
           - entity: input_number.inputnumbertest4
+            text: ""
         bubblesactive: true
         ticksactive: true
         min: 18
@@ -86,6 +90,7 @@ sections:
           rows: 3
         verticalheight: 2
         valuesbaractive: false
+        direction: rtl
       - type: tile
         entity: input_number.inputnumbertest1
         vertical: false


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
In vertical mode, direction is still named rtl and ltr, should be top to bottom and bottom to top

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

This PR fixes or closes issue: fixes #49

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies bump)
-   [ ] 📚 Documentation (fix or addition in the documentation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)